### PR TITLE
Update to support range password searching

### DIFF
--- a/SharpPwned.NET/SharpPwned.cs
+++ b/SharpPwned.NET/SharpPwned.cs
@@ -136,7 +136,6 @@ namespace SharpPwned.NET
         {
             Response response = await GETRequestAsync(parameters, URL);
             return response;
-
         }
 
         private async Task<Response> GETRequestAsync(string parameters, string overrideURL)


### PR DESCRIPTION
This PR updates the library to use the now-preferred way of checking for whether a password is pwned, [searching by range](https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange). This search method utilizes [k-Anonymity](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity) so the full password/password hash never leaves the code that wants to know whether or not it is pwned.

**Note: This DOES REMOVE the ability for the library to call to the ```/pwnedpassword/{password or hash}``` location as Troy has claimed searching by password/password hash is [going away on June 1, 2018](https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByPassword).**

Use of the library has not changed and is transparent to consumers.