### PR TITLE
Override user agent.

### DIFF
--- a/SharpPwned.NET/SharpPwned.cs
+++ b/SharpPwned.NET/SharpPwned.cs
@@ -15,10 +15,16 @@ namespace SharpPwned.NET
 
         private readonly string URL = @"https://haveibeenpwned.com/api/v2";
         private readonly string passwordRangeURL = @"https://api.pwnedpasswords.com";
+        private readonly string userAgent;
 
-        public HaveIBeenPwnedRestClient()
+        public HaveIBeenPwnedRestClient(string userAgent = null)
         {
+            this.userAgent = userAgent;
 
+            if (string.IsNullOrWhiteSpace(this.userAgent))
+            {
+                this.userAgent = "SharpPwned.NET";
+            }
         }
 
         public async Task<List<Paste>> GetPasteAccount(string account)
@@ -145,7 +151,7 @@ namespace SharpPwned.NET
 
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
             HttpResponseMessage response = null;
-            request.Headers.TryAddWithoutValidation("User-Agent", "SharpPwned.NET");
+            request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
 
             try
             {


### PR DESCRIPTION
From the API docs

> Each request to the API must be accompanied by a user agent request header. Typically this should be the name of the app consuming the service, for example "Pwnage-Checker-For-iOS". A missing user agent will result in an HTTP 403 response. A valid request would look like