### PR TITLE
- include unverified breaches parameter

### DIFF
--- a/SharpPwned.NET/SharpPwned.cs
+++ b/SharpPwned.NET/SharpPwned.cs
@@ -75,10 +75,15 @@ namespace SharpPwned.NET
 
         }
 
-        public async Task<List<Breach>> GetAccountBreaches(string account)
+        public async Task<List<Breach>> GetAccountBreaches(string account, bool? includeUnverified = false)
         {
             string api = "breachedaccount";
-            var response = await GETRequestAsync($"{api}/{account}");
+            string includeUnverifiedQueryString = string.Empty;
+            if(includeUnverified.HasValue && includeUnverified.Value)
+            {
+                includeUnverifiedQueryString = "?includeUnverified=true";
+            }
+            var response = await GETRequestAsync($"{api}/{account}{includeUnverifiedQueryString}");
 
             List<Breach> AllBreaches = new List<Breach>();
 


### PR DESCRIPTION
Troy Hunt's API allows to list also unverified breaches.
Docs says 

> the public API will not return accounts from any breaches flagged as sensitive or retired. By default, the API also won't return breaches flagged as unverified, however these can be included by using the following parameter: includeUnverified

 
Signed-off-by: Andrej Had <hopp@ygg.sk>